### PR TITLE
Add certutil.exe support

### DIFF
--- a/exe2hex.py
+++ b/exe2hex.py
@@ -94,7 +94,7 @@ class BinaryInput:
             self.exe_filename = os.path.basename(self.exe_file)
         else:
             self.exe_filename = "binary.exe"
-        verbose_msg("Input EXE filename: %s" % self.exe_filename)
+        verbose_msg("Output EXE filename: %s" % self.exe_filename)
 
         # debug.exe has a limitation when renaming files > 8 characters (8.3 filename)
         self.short_file = os.path.splitext(self.exe_filename)[0][:8]

--- a/exe2hex.py
+++ b/exe2hex.py
@@ -675,7 +675,7 @@ if __name__ == "__main__":
         print("Example:")
         print(" $ %s -x /usr/share/windows-binaries/sbd.exe" % sys.argv[0])
         print(" $ %s -x /usr/share/windows-binaries/nc.exe -m 2 -o /var/www/html/nc.txt -cc" % sys.argv[0])
-        print(" $ cat /usr/share/windows-binaries/whoami.exe | %s -s -m 3 -o debug.bat -p ps.cmd" % sys.argv[0])
+        print(" $ cat /usr/share/windows-binaries/whoami.exe | %s -s -m 3 -o ps.cmd" % sys.argv[0])
         print('')
         print('--- --- --- --- --- --- --- --- --- --- --- --- --- --- ---')
         print('')


### PR DESCRIPTION
While in the process of adding support for certutil.exe, I had to implement a generic command line argument -m (method) that takes a choice of debug, certutil, or posh and -o (output file), and remove -b and -p. The main reason to consider this change is to not avoid additional command line arguments for each method that may be added to the script in the future, as there is a finite number of letters in the alphabet :)

Please note that I tried to reuse the code where possible, keep the changes to a minimum and avoid renaming functions/variables unnecessarily so that the overall logic and structure of the script remains in-tact. 

Suggestion to consider: if the characters used by base64 will not break the intention of the script, consider using it as an additional encoding scheme as it is more efficient in size than hex. It might however defeat the purpose of the tool (it is called exe2hex after all ;P)